### PR TITLE
feat: add Publisher maxAttempts

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,10 @@ const rabbit = new Connection()
 
 // See API docs for all options
 const pro = rabbit.createPublisher({
-  // call Channel.confirmSelect()
+  // enable acknowledgements (resolve with error if publish is unsuccessful)
   confirm: true,
+  // enable retries
+  maxAttempts: 2,
   // ensure the existence of an exchange before we use it otherwise we could
   // get a NOT_FOUND error
   exchanges: [{exchange: 'my-events', type: 'topic', autoDelete: true}]

--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -191,7 +191,7 @@ class Connection extends EventEmitter {
    * Create a message publisher that can recover from dropped connections.
    * This will create a dedicated Channel, declare queues, declare exchanges,
    * and declare bindings. If the connection is reset, then all of this setup
-   * will rerun on a new Channel.
+   * will rerun on a new Channel. This also supports retries.
    */
   createPublisher(props: PublisherProps = {}): Publisher {
     let _ch: Channel|undefined
@@ -244,7 +244,7 @@ class Connection extends EventEmitter {
     }
 
     return Object.assign(emitter, {
-      publish: maxAttempts >= 2 ? publishWithRetry : publish,
+      publish: maxAttempts > 1 ? publishWithRetry : publish,
       close() {
         isClosed = true
         if (pendingSetup)

--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -197,6 +197,7 @@ class Connection extends EventEmitter {
     let _ch: Channel|undefined
     let pendingSetup: Promise<Channel>|undefined
     let isClosed = false
+    let maxAttempts = props.maxAttempts || 1
     const emitter = new EventEmitter()
 
     const setup = async () => {
@@ -219,17 +220,31 @@ class Connection extends EventEmitter {
       return ch
     }
 
+    const publish = (envelope: Envelope, body: MessageBody) => {
+      if (isClosed)
+        return Promise.reject(new AMQPChannelError('CLOSED', 'publisher is closed'))
+      if (!_ch?.active) {
+        if (!pendingSetup)
+          pendingSetup = setup().finally(() =>{ pendingSetup = undefined })
+        return pendingSetup.then(ch => ch.basicPublish(envelope, body))
+      }
+      return _ch.basicPublish(envelope, body)
+    }
+
+    const publishWithRetry = async (envelope: Envelope, body: MessageBody) => {
+      let attempts = 0
+      while (true) try {
+        return await publish(envelope, body)
+      } catch (err) {
+        if (++attempts >= maxAttempts)
+          throw err
+        else // notify & loop
+          emitter.emit('retry', err, envelope, body)
+      }
+    }
+
     return Object.assign(emitter, {
-      publish(envelope: Envelope, body: MessageBody) {
-        if (isClosed)
-          return Promise.reject(new AMQPChannelError('CLOSED', 'publisher is closed'))
-        if (!_ch?.active) {
-          if (!pendingSetup)
-            pendingSetup = setup().finally(() =>{ pendingSetup = undefined })
-          return pendingSetup.then(ch => ch.basicPublish(envelope, body))
-        }
-        return _ch.basicPublish(envelope, body)
-      },
+      publish: maxAttempts >= 2 ? publishWithRetry : publish,
       close() {
         isClosed = true
         if (pendingSetup)

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,6 +75,12 @@ export interface HeaderFields {
 export interface PublisherProps {
   /** Enable publish-confirm mode. See {@link Channel.confirmSelect} */
   confirm?: boolean,
+  /** (default=1) Maximum publish attempts. Retries are disabled by default.
+   * Increase this number to retry when a publish fails. The Connection options
+   * acquireTimeout, retryLow, and retryHigh will affect time between retries.
+   * Each failed attempt will also emit a "retry" event.
+   * */
+  maxAttempts?: number,
   /** see {@link Channel.on}('basic.return') */
   onReturn?: (msg: ReturnedMessage) => void,
   /**
@@ -105,6 +111,8 @@ export interface Publisher extends EventEmitter {
   publish(envelope: string|Envelope, body: MessageBody): Promise<void>,
   /** Same as {@link Channel.on}('basic.return') */
   on(name: 'basic.return', cb: (msg: ReturnedMessage) => void): this;
+  /** See maxAttempts. Emitted each time a failed publish will be retried. */
+  on(name: 'retry', cb: (err: any, envelope: Envelope, body: MessageBody) => void): this;
   /** Close the underlying channel */
   close(): Promise<void>
 }


### PR DESCRIPTION
Added a new option to Connection.createPublisher:

`maxAttempts` (default=1) Maximum publish attempts. Retries are disabled by default. Increase this number to retry when a publish fails. The Connection options acquireTimeout, retryLow, and retryHigh will affect time between retries. Each failed attempt will also emit a "retry" event. If the final attempt fails, then the publish is rejected with the error.

```javascript
const pro = rabbit.createPublisher({
  maxAttempts: 2
})

pro.on('retry', (err, envelope, body) => {
  console.log('publish attempt failed', err, envelope, body)
})

await pro.publish({exchange: 'abc', routingKey: 'xyz'}, 'my-payload-data')
// example: attempt 1 (fail) ... attempt 2 (fail) ... reject
// example: attempt 1 (fail) ... attempt 2 (success) ... resolve
```
