### PR TITLE
fix: AMQPConnectionError [AMQPError]: client received unexpected method ch1:queue.declare-ok

### DIFF
--- a/src/Channel.ts
+++ b/src/Channel.ts
@@ -147,15 +147,15 @@ class Channel extends EventEmitter {
 
   /** @internal */
   _resolveCallback<T extends keyof MethodParams>(fullName: T, params: MethodParams[T]) {
-    const pair = this._state.callbacks[0]
-    if (!pair || pair[0] !== fullName) {
+    // try to find the first index with such fullName
+    const index = this._state.callbacks.findIndex(pair => pair [0] == fullName)
+    if (index < 0) {
       // this is a bug; should never happen
       throw new AMQPConnectionError('UNEXPECTED_FRAME',
         `client received unexpected method ch${this.id}:${fullName} ${JSON.stringify(params)}`)
-    } else {
-      this._state.callbacks.shift()
-      pair[1].resolve(params)
     }
+    const pairs = this._state.callbacks.splice(index, 1)
+    pairs[0][1].resolve(params)
   }
 
   /** @internal Try to reject a pending callback or emit the error */


### PR DESCRIPTION
I have been using this library but from time to time (2-3 out of 20), I will encounter a mysterious exception from this lib.

I find that the situation is that the order of `_resolveCallback` calls may not be aligned with `_addCallback`.
This PR tries to find the first item with the same fullName before giving up and throw the exception.