### PR TITLE
fix: out-of-order RPCs

### DIFF
--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -119,6 +119,10 @@ class Connection extends EventEmitter {
       throw new Error('maximum number of AMQP Channels already open')
     const ch = new Channel(id, this)
     this._state.leased.set(id, ch)
+    ch.once('close', () => {
+      this._state.leased.delete(id)
+      this._checkEmpty()
+    })
     await ch._invoke('channel.open', {})
     return ch
   }


### PR DESCRIPTION
**fix: nowait=true is ignored**
This is a problematic feature that no one should use. There just isn't
a good way to handle it. Removing support won't break anything either.

**fix: one RPC at a time**
AMQP does not support RPC pipelining!
 C = client
 S = server

 C:basic.consume
 C:queue.declare
 ...
 S:queue.declare  <- response may arrive out of order
 S:basic.consume

 So we can only have one RPC in-flight at a time:
 C:basic.consume
 S:basic.consume
 C:queue.declare
 S:queue.declare
