### PR TITLE
Consumer return code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v4.1.0
+- feat: Consumer return code [#21](https://github.com/cody-greene/node-rabbitmq-client/pull/21)
+
 # v4.0.0
 BREAKING CHANGES:
 - dropped node 14 (EOL 2023-04-30)

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ const sub = rabbit.createConsumer({
   queueBindings: [{exchange: 'my-events', routingKey: 'users.*'}],
 }, async (msg) => {
   console.log('received message (user-events)', msg)
-  // The message is automatically acknowledged when this function ends.
-  // If this function throws an error, then msg is NACK'd (rejected) and
+  // The message is automatically acknowledged (BasicAck) when this function ends.
+  // If this function throws an error, then msg is rejected (BasicNack) and
   // possibly requeued or sent to a dead-letter exchange. You can also return a
   // status code from this callback to control the ack/nack behavior
   // per-message.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ const sub = rabbit.createConsumer({
   console.log('received message (user-events)', msg)
   // The message is automatically acknowledged when this function ends.
   // If this function throws an error, then msg is NACK'd (rejected) and
-  // possibly requeued or sent to a dead-letter exchange
+  // possibly requeued or sent to a dead-letter exchange. You can also return a
+  // status code from this callback to control the ack/nack behavior
+  // per-message.
 })
 
 sub.on('error', (err) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rabbitmq-client",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "Robust, typed, RabbitMQ (0-9-1) client library",
   "homepage": "https://github.com/cody-greene/node-rabbitmq-client",
   "repository": {

--- a/src/Consumer.ts
+++ b/src/Consumer.ts
@@ -79,8 +79,15 @@ export declare interface Consumer {
  *
  * The callback is called for each incoming message. If it throws an error or
  * returns a rejected Promise then the message is NACK'd (rejected) and
- * possibly requeued, or sent to a dead-letter exchange. Otherwise the message
- * is automatically ACK'd and removed from the queue.
+ * possibly requeued, or sent to a dead-letter exchange. The callback can also
+ * return a numeric status code to control the ACK/NACK behavior. The
+ * {@link ConsumerReturnCode} enum is provided for convenience.
+ *
+ * ACK/NACK behavior when the callback:
+ * - throws an error - BasicNack(requeue=ConsumerProps.requeue)
+ * - returns 0 or undefined - BasicAck
+ * - returns 1 - BasicNack(requeue=true)
+ * - returns 2 - BasicNack(requeue=false)
  *
  * About concurency: For best performance, you'll likely want to start with
  * concurrency=X and qos.prefetchCount=2X. In other words, up to 2X messages
@@ -107,10 +114,6 @@ export declare interface Consumer {
  *   await reply('my-response-data')
  *
  *   // optionally return a status code
- *   // 0 or undefined - ack
- *   // 1              - nack(requeue=true)
- *   // 2              - nack(requeue=false)
- *   // An enum type is provided for convenience
  *   return ConsumerReturnCode.OK // 0
  * })
  *

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,10 +3,11 @@ import {Connection, PublisherProps, Publisher} from './Connection'
 export default Connection
 export {Connection}
 export {AMQPConnectionError, AMQPChannelError, AMQPError} from './exception'
+export {ConsumerReturnCode} from './Consumer'
 
 export type {PublisherProps, Publisher}
 export type {RPCClient, RPCProps} from './RPCClient'
-export type {Consumer, ConsumerProps, ConsumerHandler, ConsumerReturnCode} from './Consumer'
+export type {Consumer, ConsumerProps, ConsumerHandler} from './Consumer'
 export type {Channel} from './Channel'
 export type {ConnectionOptions} from './normalize'
 export type {Cmd, Decimal, ReturnedMessage, SyncMessage, AsyncMessage, Envelope, MessageBody, HeaderFields, MethodParams} from './codec'

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ export {AMQPConnectionError, AMQPChannelError, AMQPError} from './exception'
 
 export type {PublisherProps, Publisher}
 export type {RPCClient, RPCProps} from './RPCClient'
-export type {Consumer, ConsumerProps, ConsumerHandler} from './Consumer'
+export type {Consumer, ConsumerProps, ConsumerHandler, ConsumerReturnCode} from './Consumer'
 export type {Channel} from './Channel'
 export type {ConnectionOptions} from './normalize'
 export type {Cmd, Decimal, ReturnedMessage, SyncMessage, AsyncMessage, Envelope, MessageBody, HeaderFields, MethodParams} from './codec'

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import {Connection, PublisherProps, Publisher} from './Connection'
 export default Connection
 export {Connection}
 export {AMQPConnectionError, AMQPChannelError, AMQPError} from './exception'
-export {ConsumerReturnCode} from './Consumer'
+export {ConsumerStatus} from './Consumer'
 
 export type {PublisherProps, Publisher}
 export type {RPCClient, RPCProps} from './RPCClient'

--- a/test/consumer.ts
+++ b/test/consumer.ts
@@ -1,5 +1,5 @@
 import test from 'tape'
-import Connection, {AsyncMessage, ConsumerReturnCode} from '../src'
+import Connection, {AsyncMessage, ConsumerStatus} from '../src'
 import {PREFETCH_EVENT} from '../src/Consumer'
 import {expectEvent, createDeferred, Deferred} from '../src/util'
 import {sleep, createIterableConsumer} from './util'
@@ -287,23 +287,17 @@ test('Consumer concurrency with noAck=true', async (t) => {
 })
 
 test('Consumer return codes', async (t) => {
-  type MsgEvent = [AsyncMessage, Deferred<ConsumerReturnCode>]
   const rabbit = new Connection(RABBITMQ_URL)
   const queue = '__test_03f0726440598228'
   const deadqueue = '__test_fadb49f36193d615'
   const exchange = '__test_db6d7203284a44c2'
-  const msgevt = Symbol('msgevent')
-  const sub = rabbit.createConsumer({
+  const sub = createIterableConsumer(rabbit, {
     queue,
     requeue: false,
     queueOptions: {
       exclusive: true,
       arguments: {'x-dead-letter-exchange': exchange}
     },
-  }, (msg) => {
-    const dfd = createDeferred<ConsumerReturnCode>()
-    sub.emit(msgevt, [msg, dfd] as MsgEvent)
-    return dfd.promise
   })
   const dead = createIterableConsumer(rabbit, {
     queue: deadqueue,
@@ -318,28 +312,28 @@ test('Consumer return codes', async (t) => {
 
   // can drop by default
   await ch.basicPublish(queue, 'red')
-  const [msg1, dfd1] = await expectEvent<MsgEvent>(sub, msgevt)
+  const msg1 = await sub.read()
   t.equal(msg1.redelivered, false)
-  dfd1.reject(new Error('expected'))
+  msg1.reject(new Error('expected'))
   const err = await expectEvent(sub, 'error')
   t.equal(err.message, 'expected')
-  const [msg2, dfd2] = await dead.read()
+  const msg2 = await dead.read()
   t.equal(msg2.body, 'red', 'got dead-letter')
-  dfd2.resolve()
+  msg2.resolve()
 
   // can selectively requeue
   await ch.basicPublish(queue, 'blue')
-  const [msg3, dfd3] = await expectEvent<MsgEvent>(sub, msgevt)
+  const msg3 = await sub.read()
   t.equal(msg3.redelivered, false)
-  dfd3.resolve(ConsumerReturnCode.REQUEUE)
-  const [msg4, dfd4] = await expectEvent<MsgEvent>(sub, msgevt)
+  msg3.resolve(ConsumerStatus.REQUEUE)
+  const msg4 = await sub.read()
   t.equal(msg4.redelivered, true, 'msg redelivered')
 
   // can explicitly drop
-  dfd4.resolve(ConsumerReturnCode.DROP)
-  const [msg5, dfd5] = await dead.read()
+  msg4.resolve(ConsumerStatus.DROP)
+  const msg5 = await dead.read()
   t.equal(msg5.body, 'blue', 'message dropped')
-  dfd5.resolve()
+  msg5.resolve()
 
   await ch.close()
   await sub.close()


### PR DESCRIPTION
A ConsumerHandler can return a status code for precise control of ack/nack behavior. An enum type is provided for convenience, but it's not necessary.

```typescript
import {ConsumerStatus} from 'rabbitmq-client'

const sub = rabbit.createConsumer({
  queue: 'my-queue',
  requeue: false // behavior with exceptions
}, async (msg) => {
  // optionally return a status code
  // 0 or undefined - ack
  // 1              - nack(requeue=true)
  // 2              - nack(requeue=false)
  return ConsumerStatus.REQUEUE // 1
})
```

- [x] add some tests
