### PR TITLE
lazy channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # v4.2.0
-- [#29](https://github.com/cody-greene/node-rabbitmq-client/pull/29) Added some management methods to the top-level Connection interface. You can create/delete queues, exchanges, and bindings. A special channel is implicitly created and maintained internally, so you don't have to worry about it.
+- [#29](https://github.com/cody-greene/node-rabbitmq-client/pull/29) Added some management methods to the top-level Connection interface. You can create/delete queues, exchanges, and bindings. A special channel is implicitly created and maintained internally, so you don't have to worry about it. New methods:
+- basicGet
+- exchangeBind
+- exchangeDeclare
+- exchangeDelete
+- exchangeUnbind
+- queueBind
+- queueDeclare
+- queueDelete
+- queuePurge
+- queueUnbind
 
 # v4.1.0
 - feat: Consumer return code [#21](https://github.com/cody-greene/node-rabbitmq-client/pull/21)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v4.2.0
+- [#29](https://github.com/cody-greene/node-rabbitmq-client/pull/29) Added some management methods to the top-level Connection interface. You can create/delete queues, exchanges, and bindings. A special channel is implicitly created and maintained internally, so you don't have to worry about it.
+
 # v4.1.0
 - feat: Consumer return code [#21](https://github.com/cody-greene/node-rabbitmq-client/pull/21)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rabbitmq-client",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "Robust, typed, RabbitMQ (0-9-1) client library",
   "homepage": "https://github.com/cody-greene/node-rabbitmq-client",
   "repository": {

--- a/src/Channel.ts
+++ b/src/Channel.ts
@@ -577,7 +577,7 @@ export class Channel extends EventEmitter {
   basicGet(queue?: string): Promise<undefined|SyncMessage>
   /** @ignore */
   basicGet(params?: string|MethodParams[Cmd.BasicGet]): Promise<undefined|SyncMessage>
-  basicGet(params?: string|MethodParams[Cmd.BasicGet]): Promise<undefined|SyncMessage> {
+  basicGet(params: string|MethodParams[Cmd.BasicGet] = ''): Promise<undefined|SyncMessage> {
     if (typeof params == 'string') {
       params = {queue: params}
     }

--- a/src/Channel.ts
+++ b/src/Channel.ts
@@ -572,8 +572,15 @@ export class Channel extends EventEmitter {
   basicAck(params: MethodParams[Cmd.BasicAck]): void {
     return this._invokeNowait(Cmd.BasicAck, params)
   }
-  /** Request a single message from a queue */
-  basicGet(params: MethodParams[Cmd.BasicGet]): Promise<undefined|SyncMessage> {
+  /** Request a single message from a queue. Useful for testing. */
+  basicGet(params: MethodParams[Cmd.BasicGet]): Promise<undefined|SyncMessage>
+  basicGet(queue?: string): Promise<undefined|SyncMessage>
+  /** @ignore */
+  basicGet(params?: string|MethodParams[Cmd.BasicGet]): Promise<undefined|SyncMessage>
+  basicGet(params?: string|MethodParams[Cmd.BasicGet]): Promise<undefined|SyncMessage> {
+    if (typeof params == 'string') {
+      params = {queue: params}
+    }
     return this._invoke(Cmd.BasicGet, Cmd.BasicGetOK, {...params, rsvp1: 0})
   }
   /** Reject one or more incoming messages. */
@@ -637,7 +644,7 @@ export class Channel extends EventEmitter {
   queueDelete(params: MethodParams[Cmd.QueueDelete]): Promise<MethodParams[Cmd.QueueDeleteOK]>
   queueDelete(queue?: string): Promise<MethodParams[Cmd.QueueDeleteOK]>
   /** @ignore */
-  queueDelete(params: string|MethodParams[Cmd.QueueDelete]): Promise<MethodParams[Cmd.QueueDeleteOK]>
+  queueDelete(params?: string|MethodParams[Cmd.QueueDelete]): Promise<MethodParams[Cmd.QueueDeleteOK]>
   queueDelete(params: string|MethodParams[Cmd.QueueDelete] = ''): Promise<MethodParams[Cmd.QueueDeleteOK]> {
     if (typeof params == 'string') {
       params = {queue: params}
@@ -650,7 +657,7 @@ export class Channel extends EventEmitter {
   queuePurge(queue?: string): Promise<MethodParams[Cmd.QueuePurgeOK]>
   queuePurge(params: MethodParams[Cmd.QueuePurge]): Promise<MethodParams[Cmd.QueuePurgeOK]>
   /** @ignore */
-  queuePurge(params: string|MethodParams[Cmd.QueuePurge]): Promise<MethodParams[Cmd.QueuePurgeOK]>
+  queuePurge(params?: string|MethodParams[Cmd.QueuePurge]): Promise<MethodParams[Cmd.QueuePurgeOK]>
   queuePurge(params: string|MethodParams[Cmd.QueuePurge] = ''): Promise<MethodParams[Cmd.QueuePurgeOK]> {
     if (typeof params == 'string') {
       params = {queue: params}

--- a/test/behavior.ts
+++ b/test/behavior.ts
@@ -767,6 +767,22 @@ test('out-of-order RPC', async (t) => {
   await rabbit.close()
 })
 
+test('lazy channel', async (t) => {
+  const rabbit = new Connection(RABBITMQ_URL)
+
+  t.comment('can manage queues without explicitly creating a channel')
+  const {queue} = await rabbit.queueDeclare({exclusive: true})
+
+  t.comment('lazy channel can recover from errors')
+  const [res] = await Promise.allSettled([
+    rabbit.queueDeclare({queue: '6b5a171726e573d5', passive: true})
+  ])
+  t.equal(res.status === 'rejected' && res.reason.code, 'NOT_FOUND')
+  await rabbit.queueDeclare({queue, passive: true})
+
+  t.comment('lazy channel auto-closes')
+  await rabbit.close()
+})
+
 // TODO opt.frameMax
-// TODO frame errors / unexpected channel
 // TODO codec


### PR DESCRIPTION
Add some management methods to the top-level Connection interface. You
can create/delete queues, exchanges, and bindings. A special channel is
implicitly created and maintained internally, so you don't have to
worry about it.
