### PR TITLE
fix: check frame size before socket write

### DIFF
--- a/src/Channel.ts
+++ b/src/Channel.ts
@@ -415,7 +415,7 @@ export class Channel extends EventEmitter {
       type: FrameType.METHOD,
       channelId: this.id,
       methodId: req,
-      params: params} as MethodFrame)
+      params: params} as MethodFrame, this._state.maxFrameSize)
     const rpc = [dfd, req, res, it] as const
     if (this._state.rpc)
       this._state.rpcBuffer.push(rpc)
@@ -446,7 +446,7 @@ export class Channel extends EventEmitter {
       methodId: methodId,
       params: params
     }
-    this._state.stream.write(genFrame(frame as MethodFrame), (err) => {
+    this._state.stream.write(genFrame(frame as MethodFrame, this._state.maxFrameSize), (err) => {
       if (err) {
         err.message += '; ' + Cmd[methodId]
         this._conn.emit('error', err)

--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -496,7 +496,7 @@ export class Connection extends EventEmitter {
 
   /** @internal */
   _writeMethod(params: MethodFrame): void {
-    const frame = encodeFrame(params)
+    const frame = encodeFrame(params, this._state.frameMax)
     this._socket.write(frame)
   }
 


### PR DESCRIPTION
Checking for oversized frames, client-side, prevents a connection-level
error. This applies to any method that allows large strings or tables,
like queueBind, queueDeclare, etc. Since this error is contained to the
originating channel, other publishers/consumers on different channels
will remain alive.

```javascript
const pub = rabbit.createPublisher({confirm: true})
const bigstring = 'x'.repeat(4100)

// Uncaught AMQPChannelError: frame size of 4153 bytes exceeds maximum of 4096
await pub.send({routingKey: 'foo', headers: {bigstring}}, 'oops')
```
