### PR TITLE
fix: aws-lambda, send() won't hang after reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## v5.5.1
+## v4.5.2
+
+### Bug Fixes
+- aws-lambda, send() won't hang after reconnect (#46)
+
+## v4.5.1
 
 ### Bug Fixes
 - Check frame size before socket write (#41)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rabbitmq-client",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "description": "Robust, typed, RabbitMQ (0-9-1) client library",
   "engines": {
     "node": ">=16"

--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -520,7 +520,8 @@ export class Connection extends EventEmitter {
               this._socket.uncork()
             }
             const strcode = ReplyCode[frame.params.replyCode] || String(frame.params.replyCode)
-            const msg = Cmd[frame.params.methodId] + ': ' + frame.params.replyText
+            const souceMethod = frame.params.methodId ? Cmd[frame.params.methodId] + ': ' : ''
+            const msg = souceMethod + frame.params.replyText
             this._socket.emit('error', new AMQPConnectionError(strcode, msg))
             break
           case Cmd.ConnectionCloseOK:

--- a/src/util.ts
+++ b/src/util.ts
@@ -120,7 +120,10 @@ export class EncoderStream<T=unknown> extends Writable {
   writeAsync: (it: Iterator<T, void>) => Promise<void> = promisify(this.write)
   _destroy(err: Error | null, cb: (err?: Error | null) => void): void {
     this._out.removeListener('drain', this._loop)
-    this._cur = undefined
+    if (this._cur) {
+      this._cur[1](err)
+      this._cur = undefined
+    }
     cb(err)
   }
   _write(it: Iterator<T, void>, enc: unknown, cb: (error?: Error | null) => void): void {

--- a/test/stream-helpers.ts
+++ b/test/stream-helpers.ts
@@ -139,7 +139,7 @@ test('EncoderStream should stop writing when destroyed', async () => {
   assert.equal(socket.read(), null, 'green should not be written')
 })
 
-test('EncoderStream invokes write callback when destroyed', {only: true}, async () => {
+test('EncoderStream invokes write callback when destroyed', async () => {
   const it = ['red', 'blue', 'green'].values()
   const socket = new StubSocket({objectMode: true, highWaterMark: 1})
   const stream = new EncoderStream<string>(socket)

--- a/test/stream-helpers.ts
+++ b/test/stream-helpers.ts
@@ -138,3 +138,14 @@ test('EncoderStream should stop writing when destroyed', async () => {
   assert.equal(socket.read(), 'blue')
   assert.equal(socket.read(), null, 'green should not be written')
 })
+
+test('EncoderStream invokes write callback when destroyed', {only: true}, async () => {
+  const it = ['red', 'blue', 'green'].values()
+  const socket = new StubSocket({objectMode: true, highWaterMark: 1})
+  const stream = new EncoderStream<string>(socket)
+  stream.on('error', () => { /* ignored */ })
+
+  const promise = stream.writeAsync(it)
+  stream.destroy(new Error('bad news'))
+  await assert.rejects(() => promise, {message: 'bad news'})
+})


### PR DESCRIPTION
Fixes https://github.com/cody-greene/node-rabbitmq-client/issues/45

If the EncoderStream is destroyed after partially squeezing an
iterator, then it should invoke the saved write-callback with an error.
This only seems to happen, in practice, with aws lambda when the
exchange drops the connection while the lambda context is suspended.
