### PR TITLE
feat: connection.onConnect()

### DIFF
--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -702,7 +702,7 @@ export class Connection extends EventEmitter {
         }
         resolve()
       }
-      if (timeout >= 0) {
+      if (timeout > 0) {
          timer = setTimeout(() => {
           this.removeListener('connection', onConnection)
           this.removeListener('error', onError)

--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -39,7 +39,7 @@ function raceWithTimeout<T>(promise: Promise<T>, ms: number, msg: string): Promi
 
 const CLIENT_PROPERTIES = {
   product: 'rabbitmq-client',
-  version: '4.5.3',
+  version: '4.6.0',
   platform: `node.js-${process.version}`,
   capabilities: {
     'basic.nack': true,
@@ -664,6 +664,61 @@ export class Connection extends EventEmitter {
   /** True if the connection is established and unblocked. See also {@link Connection#on:BLOCKED | Connection#on('connection.blocked')}) */
   get ready(): boolean {
     return this._state.readyState === READY_STATE.OPEN && !this._socket.writableCorked
+  }
+
+  /**
+   * Returns a promise which is resolved when the connection is established.
+   * WARNING: if timeout=0 and you call close() before the client can connect,
+   * then this promise may never resolve!
+   * @param timeout Milliseconds to wait before giving up and rejecting the
+   * promise. Use 0 for no timeout.
+   * @param disableAutoClose By default this will automatically call
+   * `connection.close()` when the timeout is reached. If
+   * disableAutoClose=true, then connection will instead continue to retry
+   * after this promise is rejected. You can call `close()` manually.
+  **/
+  onConnect(timeout = 10_000, disableAutoClose = false) :Promise<void> {
+    if (this.ready) {
+      return Promise.resolve()
+    }
+    if (this._state.readyState >= READY_STATE.CLOSING) {
+      return Promise.reject(new Error('RabbitMQ failed to connect in time; Connection closed by client'))
+    }
+    // create this early for a useful stack trace
+    const pessimisticError = new Error('RabbitMQ failed to connect in time')
+    return new Promise((resolve, reject) => {
+      let timer :NodeJS.Timeout|undefined
+      // capture the most recent connection Error so it can be included in the
+      // final rejection
+      let lastError: unknown
+      const onError = (err: unknown) => {
+        lastError = err
+      }
+      const onConnection = () => {
+        this.removeListener('connection', onConnection)
+        this.removeListener('error', onError)
+        if (timer != null) {
+          clearTimeout(timer)
+        }
+        resolve()
+      }
+      if (timeout >= 0) {
+         timer = setTimeout(() => {
+          this.removeListener('connection', onConnection)
+          this.removeListener('error', onError)
+          if (!disableAutoClose) {
+           /* close should never throw but catch and ignore just in case */
+            this.close().catch(() => {})
+          }
+          if (lastError) {
+            pessimisticError.cause = lastError
+          }
+          reject(pessimisticError)
+        }, timeout)
+      }
+      this.on('error', onError)
+      this.on('connection', onConnection)
+    })
   }
 }
 

--- a/test/behavior.ts
+++ b/test/behavior.ts
@@ -2,7 +2,7 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 import Connection, {AsyncMessage} from '../src'
 import {createServer} from 'node:net'
-import {expectEvent, createDeferred, Deferred} from '../src/util'
+import {expectEvent, createDeferred, Deferred, READY_STATE} from '../src/util'
 import {MethodFrame, DataFrame, Cmd, FrameType} from '../src/codec'
 import {useFakeServer} from './util'
 
@@ -221,7 +221,7 @@ test('will reconnect when connection.close is received from the server', async (
   await rabbit.close()
 })
 
-test('will reconnect when receiving a frame for an unexpected channel', {only: true}, async () => {
+test('will reconnect when receiving a frame for an unexpected channel', async () => {
   const [port, server] = await useFakeServer([
     async (socket, next) => {
       let frame
@@ -886,4 +886,24 @@ test('client-side frame size checks', async () => {
   await rabbit.close()
 })
 
-// TODO codec
+test('connection.onConnect: reject', async (t) => {
+  const rabbit = new Connection('amqp://wrong:password@127.0.0.1:5672')
+  await assert.rejects(rabbit.onConnect(10), (err: any) => {
+    assert.match(err.message, /failed to connect in time/)
+    // error.cause has recent connection error
+    assert.equal(err.cause.code, 'ECONNREFUSED')
+    return true
+  })
+  assert.equal(rabbit.ready, false)
+  // reject immediately when already closed
+  await assert.rejects(rabbit.onConnect(10), /closed by client/)
+})
+
+test('connection.onConnect: resolve', async (t) => {
+  const rabbit = new Connection(RABBITMQ_URL)
+  await rabbit.onConnect(500)
+  assert(rabbit.ready, 'connection ready')
+  // should still resolve when already connected
+  await rabbit.onConnect(500)
+  assert(true, 'connection still ready')
+})

--- a/test/behavior.ts
+++ b/test/behavior.ts
@@ -891,7 +891,7 @@ test('connection.onConnect: reject', async (t) => {
   await assert.rejects(rabbit.onConnect(10), (err: any) => {
     assert.match(err.message, /failed to connect in time/)
     // error.cause has recent connection error
-    assert.equal(err.cause.code, 'ECONNREFUSED')
+    assert(err.cause instanceof Error)
     return true
   })
   assert.equal(rabbit.ready, false)
@@ -906,4 +906,5 @@ test('connection.onConnect: resolve', async (t) => {
   // should still resolve when already connected
   await rabbit.onConnect(500)
   assert(true, 'connection still ready')
+  await rabbit.close()
 })


### PR DESCRIPTION
```typescript
/**
 * Returns a promise which is resolved when the connection is
 * established. WARNING: if timeout=0 and you call close() before the
 * client can connect, then this promise may never resolve!
 *
 * @param timeout Milliseconds to wait before giving up and rejecting
 * the promise. Use 0 for no timeout.
 *
 * @param disableAutoClose By default this will automatically call
 * `connection.close()` when the timeout is reached. If
 * disableAutoClose=true, then connection will instead continue to
 * retry after this promise is rejected. You can call `close()`
 * manually.
**/
onConnect(timeout = 10_000, disableAutoClose = false) :Promise<void>
```

You can use it like this:
```javascript
async function makeRabbit() {
  const rabbit = new Connection()
  await rabbit.onConnect(10_000)
  rabbit.on('error', ...)
  // ...
  return rabbit
}
```
