### PR TITLE
fix: lazy channel should not get perma-stuck 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v5.0.1
+### Bug Fixes
+- 38c61f5 lazy channel should not get perma-stuck
+
 ## v5.0.0
 ### BREAKING CHANGES:
 #### 6766969 drop support for node 16

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rabbitmq-client",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Robust, typed, RabbitMQ (0-9-1) client library",
   "engines": {
     "node": ">=16"

--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -39,7 +39,7 @@ function raceWithTimeout<T>(promise: Promise<T>, ms: number, msg: string): Promi
 
 const CLIENT_PROPERTIES = {
   product: 'rabbitmq-client',
-  version: '5.0.0',
+  version: '5.0.1',
   platform: `node.js-${process.version}`,
   capabilities: {
     'basic.nack': true,

--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -162,7 +162,7 @@ export class Connection extends EventEmitter {
     // shouldn't be noticable. And who needs that many Channels anyway!?
     const id = this._state.leased.pick()
     if (id > this._state.channelMax)
-      throw new Error('maximum number of AMQP Channels already open')
+      throw new Error(`maximum number of AMQP Channels already opened (${this._state.channelMax})`)
     const ch = new Channel(id, this)
     this._state.leased.set(id, ch)
     ch.once('close', () => {
@@ -588,8 +588,11 @@ export class Connection extends EventEmitter {
     if (ch instanceof Promise) {
       return ch
     }
-    if (ch == null || !ch.active) {
+    if (ch == null || !ch.active) try {
       return this._state.lazyChannel = await (this._state.lazyChannel = this.acquire())
+    } catch (err) {
+      this._state.lazyChannel = void 0
+      throw err
     }
     return ch
   }

--- a/test/behavior.ts
+++ b/test/behavior.ts
@@ -786,6 +786,21 @@ test('lazy channel', {timeout: 250}, async () => {
   await rabbit.close()
 })
 
+test('lazy channel recovers from acquisition errors', async () => {
+  const rabbit = autoTeardown(new Connection({
+    url: RABBITMQ_URL,
+    maxChannels: 1
+  }))
+  const ch = autoTeardown(await rabbit.acquire())
+
+  await assert.rejects(rabbit.queueDeclare({queue: '__5a87c00901794671__', exclusive: true})
+    , /maximum number of AMQP Channels already opened/)
+
+  // Should succeed after closing the 1st channel
+  await ch.close()
+  await rabbit.queueDeclare({queue: '__5a87c00901794671__', exclusive: true})
+})
+
 test('client-side frame size checks', async () => {
   const rabbit = autoTeardown(new Connection({
     url: RABBITMQ_URL,

--- a/test/rpc.ts
+++ b/test/rpc.ts
@@ -1,8 +1,8 @@
-import test from 'node:test'
+import test, { after } from 'node:test'
 import assert from 'node:assert/strict'
 import Connection, {ConsumerHandler} from '../src'
 import {expectEvent} from '../src/util'
-import {createIterableConsumer} from './util'
+import {autoTeardown, createIterableConsumer} from './util'
 
 const RABBITMQ_URL = process.env.RABBITMQ_URL
 
@@ -26,12 +26,25 @@ test('basic rpc setup', async () => {
   await rabbit.close()
 })
 
+test('rpc can timeout', async () => {
+  const rabbit = autoTeardown(new Connection(RABBITMQ_URL))
+  const queue = '__test_52ef4e140113eb53__'
+  const client = autoTeardown(rabbit.createRPCClient({
+    confirm: true,
+    timeout: 10,
+    queues: [{queue, exclusive: true}]
+  }))
+
+  await assert.rejects(client.send({routingKey: queue}, ''), {
+    code: 'RPC_TIMEOUT'
+  })
+})
+
 test('rpc failure modes', async () => {
   const rabbit = new Connection(RABBITMQ_URL)
   const queue = '__test_52ef4e140113eb53__'
   const client = rabbit.createRPCClient({
     confirm: true,
-    timeout: 10,
     // fail until queue is created
     queues: [{queue, passive: true}]
   })
@@ -45,17 +58,7 @@ test('rpc failure modes', async () => {
   }
   assert.equal(err.code, 'NOT_FOUND', 'setup failed successfully')
 
-  const ch = await rabbit.acquire()
-  await ch.queueDeclare({queue, exclusive: true})
-  await ch.close()
-
-  // 'response can timeout'
-  try {
-    await client.send({routingKey: queue}, '')
-  } catch (_err) {
-    err = _err
-  }
-  assert.equal(err.code, 'RPC_TIMEOUT', 'got timeout error')
+  await rabbit.queueDeclare({queue, exclusive: true})
 
   // 'can encounter a ChannelError'
   const [r1, r2] = await Promise.allSettled([

--- a/test/util.ts
+++ b/test/util.ts
@@ -3,6 +3,7 @@ import {DataFrame, decodeFrame} from '../src/codec'
 import {expectEvent, createAsyncReader, createDeferred} from '../src/util'
 import Connection, {ConsumerProps, AsyncMessage, ConsumerStatus} from '../src'
 import {PassThrough} from 'node:stream'
+import { after } from 'node:test'
 
 function sleep(ms: number) {
   return new Promise(resolve => setTimeout(resolve, ms))
@@ -29,7 +30,7 @@ async function useFakeServer(cb: ConnectionCallback|Array<ConnectionCallback>) {
   const server = createServer()
   server.listen()
   await expectEvent(server, 'listening')
-  // t.teardown(() => server.close())
+  after(() => server.close())
   const addr = server.address()
   if (addr == null || typeof addr == 'string')
     throw new Error('expected server addr obj')
@@ -89,4 +90,12 @@ function createIterableConsumer(rabbit: Connection, opt: ConsumerProps) {
   })
 }
 
-export {useFakeServer, sleep, createIterableConsumer}
+interface SomeResource {
+  close() :void
+}
+function autoTeardown<T extends SomeResource>(obj: T) :T {
+  after(() => { obj.close() })
+  return obj
+}
+
+export {useFakeServer, sleep, createIterableConsumer, autoTeardown}


### PR DESCRIPTION
The lazy channel, used for management methods like `connection.queueDeclare(...)`, could get permanently stuck with a rejected promise when the channel acquisition fails. E.g. too many channels, or a timeout during reconnection. The rejected promise is now cleared out correctly.