### PR TITLE
fix: more errors scoped to Consumers & RPC

### DIFF
--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -142,7 +142,7 @@ export class Connection extends EventEmitter {
    * Allocate and return a new AMQP Channel. You MUST close the channel
    * yourself. Will wait for connect/reconnect when necessary.
    */
-  async acquire(): Promise<Channel> {
+  async acquire(opt?: {emitErrorsFromChannel?: boolean}): Promise<Channel> {
     if (this._state.readyState >= READY_STATE.CLOSING)
       throw new AMQPConnectionError('CLOSING', 'channel creation failed; connection is closing')
     if (this._state.readyState === READY_STATE.CONNECTING) {
@@ -163,7 +163,7 @@ export class Connection extends EventEmitter {
     const id = this._state.leased.pick()
     if (id > this._state.channelMax)
       throw new Error(`maximum number of AMQP Channels already opened (${this._state.channelMax})`)
-    const ch = new Channel(id, this)
+    const ch = new Channel(id, this, opt?.emitErrorsFromChannel)
     this._state.leased.set(id, ch)
     ch.once('close', () => {
       this._state.leased.delete(id)

--- a/src/Consumer.ts
+++ b/src/Consumer.ts
@@ -273,7 +273,10 @@ export class Consumer extends EventEmitter {
 
     let {_ch: ch, _props: props} = this
     if (!ch || !ch.active) {
-      ch = this._ch = await this._conn.acquire()
+      ch = this._ch = await this._conn.acquire({emitErrorsFromChannel: true})
+      ch.on('error', (err) => {
+        this.emit('error', err)
+      })
       ch.once('close', () => {
         if (!this._props.noAck) {
           // clear any buffered messages since they can't be ACKd on a new channel

--- a/src/exception.ts
+++ b/src/exception.ts
@@ -2,8 +2,8 @@
 class AMQPError extends Error {
   code: string
   /** @internal */
-  constructor(code: string, message: string) {
-    super(message)
+  constructor(code: string, message: string, cause?: unknown) {
+    super(message, {cause})
     this.name = 'AMQPError'
     this.code = code
   }

--- a/test/consumer.ts
+++ b/test/consumer.ts
@@ -136,7 +136,7 @@ test('Consumer waits for in-progress jobs to complete before reconnecting', asyn
 
   // intentionally cause a channel error so setup has to rerun
   await consumer._ch!.basicAck({deliveryTag: 404})
-  await expectEvent(rabbit, 'error')
+  await expectEvent(consumer, 'error')
   assert.ok(true, 'channel killed')
 
   await sleep(25)
@@ -190,7 +190,7 @@ test('Consumer should limit handler concurrency', async () => {
 
   // intentionally cause a channel error so setup has to rerun
   await consumer._ch!.basicAck({deliveryTag: 404})
-  await expectEvent(rabbit, 'error')
+  await expectEvent(consumer, 'error')
   assert.equal(consumer._prefetched.length, 0, 'buffered message was dropped')
 
   job2a.resolve()
@@ -243,7 +243,7 @@ test('Consumer concurrency with noAck=true', async () => {
 
   // intentionally cause a channel error
   await consumer._ch!.basicAck({deliveryTag: 404})
-  await expectEvent(rabbit, 'error')
+  await expectEvent(consumer, 'error')
   assert.equal(consumer._prefetched.length, 1, 'buffered message remains')
 
   // with noAck=true, close() should wait for remaining messages to process


### PR DESCRIPTION
Some types of async errors can now be emitted from the Channel object,
rather than the Connection object. When acquiring a basic Channel, you
can enable this:
```javascript
const ch = connection.acquire({emitErrorsFromChannel: true})
ch.on('error', (err) => ...)
```

This option is false by default, to maintain backwards compatibility.
However this is used internally by the Consumer & RPCClient classes.
Consumers will now emit these errors to help with debugging in some
situations. Similiarly, RPCClient requests may also get a "cause"
attached to some errors.
