### PR TITLE
fix: 4.1 frame size updates

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -24,7 +24,7 @@ jobs:
 
     services:
       rabbitmq:
-        image: rabbitmq:3-alpine
+        image: rabbitmq:4-alpine
         ports:
         - 5672:5672
 

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -7,7 +7,7 @@ const TCP_PORT = '5672'
 const DEFAULT_OPTS = {
   acquireTimeout: 20000,
   connectionTimeout: 10000,
-  frameMax: 4096,
+  frameMax: 8192,
   heartbeat: 60,
   maxChannels: 0x07ff, // (16bit number so the protocol max is 0xffff)
   retryLow: 1000,
@@ -25,7 +25,7 @@ export interface ConnectionOptions {
   connectionTimeout?: number,
   /** Max size, in bytes, of AMQP data frames. Protocol max is
    * 2^32-1. Actual value is negotiated with the server.
-   * @default 4096 */
+   * @default 8192 */
   frameMax?: number,
   /** Period of time, in seconds, after which the TCP connection
    * should be considered unreachable. Server may have its own max value, in

--- a/test/behavior.ts
+++ b/test/behavior.ts
@@ -841,7 +841,7 @@ test('lazy channel recovers from acquisition errors', async () => {
 test('client-side frame size checks', async () => {
   const rabbit = autoTeardown(new Connection({
     url: RABBITMQ_URL,
-    frameMax: 4096,
+    frameMax: 8192,
   }))
 
   const queue = '__test_797e71d3d9153ace'
@@ -851,18 +851,18 @@ test('client-side frame size checks', async () => {
     queue: queue,
     routingKey: 'test',
     exchange: queue,
-    arguments: {bigstring: '0'.repeat(4018)}
+    arguments: {bigstring: '0'.repeat(8114)}
   })])
   assert.equal(res.status, 'rejected')
-  assert.match(res.reason.message, /^frame size of 4097/)
+  assert.match(res.reason.message, /^frame size of 8193/)
 
   // publish with oversized header should fail
   const pub = autoTeardown(rabbit.createPublisher({confirm: true}))
   const [res2] = await Promise.allSettled([
-    pub.send({routingKey: queue, headers: {bigstring: '0'.repeat(4038)}}, null)
+    pub.send({routingKey: queue, headers: {bigstring: '0'.repeat(8134)}}, null)
   ])
   assert.equal(res2.status, 'rejected')
-  assert.match(res2.reason.message, /^frame size of 4097/)
+  assert.match(res2.reason.message, /^frame size of 8193/)
 })
 
 test('connection.onConnect: reject', async (t) => {


### PR DESCRIPTION
Rabbit version 4.1.0 was released yesterday: https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.1.0

Per the release notes, there is a breaking change to the minimum allowed frame size:
> Initial AMQP 0-9-1 Maximum Frame Size

> Before a client connection can negotiate a maximum frame size (frame_max), it must authenticate
successfully. Before the authenticated phase, a special lower frame_max value
is used.

> With this release, the value was increased from the original 4096 bytes to 8192
to accommodate larger [JWT tokens](https://www.rabbitmq.com/docs/oauth2).

> Clients that do override frame_max now must use values of 8192 bytes or greater.
We recommend using the default server value of 131072: do not override the frame_max
key in rabbitmq.conf and do not set it in the application code.

> [amqplib](https://github.com/amqp-node/amqplib/) is a popular client library that has been using
a low frame_max default of 4096. Its users must [upgrade to a compatible version](https://github.com/amqp-node/amqplib/blob/main/CHANGELOG.md#v0107)
(starting with 0.10.7) or explicitly use a higher frame_max.

Since this library defaults to a frame size of 4096, it can no longer connect to servers running version 4.1.0 or later with the default settings (it can still connect by manually overriding the frameSize).

This PR updates the default to the new minimum value of 8192. 

Note that per the release notes above, they recommend a default of 131072 -- I didn't feel comfortable bumping the default that much without more feedback which is why I just raised it to the new minimum.