### PR TITLE
fix: wrong identifier for unsigned short/uint16 in binary codec

### DIFF
--- a/src/codec.ts
+++ b/src/codec.ts
@@ -250,7 +250,7 @@ const TYPE = {
       return out.writeUInt8(val == null ? 0 : val, offset)
     }
   },
-  UINT16: {id: 66,
+  UINT16: {id: 117,
     sizeof(){ return 2 },
     decode(src: Buffer, offset: number): Decoded<number> {
       return [src.readUInt16BE(offset), offset + 2]


### PR DESCRIPTION
The 'id' for the uint16 type was wrongly reported as 0x42 ('B') instead of the correct 0x75 ('u')