### PR TITLE
fix: allow custom correlationId in RPC mode

### DIFF
--- a/src/RPCClient.ts
+++ b/src/RPCClient.ts
@@ -173,12 +173,12 @@ export class RPCClient {
    * - {@link Envelope.correlationId}
    * - {@link Envelope.expiration}
    */
-  send(envelope: Envelope, body: any): Promise<AsyncMessage>
+  send(envelope: Omit<Envelope, 'replyTo' | 'correlationId' | 'expiration'>, body: any): Promise<AsyncMessage>
   /** Send directly to a queue. Same as `send({routingKey: queue}, body)` */
   send(queue: string, body: any): Promise<AsyncMessage>
   /** @ignore */
-  send(envelope: string|Envelope, body: any): Promise<AsyncMessage>
-  async send(envelope: string|Envelope, body: any): Promise<AsyncMessage> {
+  send(envelope: string|Omit<Envelope, 'replyTo' | 'correlationId' | 'expiration'>, body: any): Promise<AsyncMessage>
+  async send(envelope: string|Omit<Envelope, 'replyTo' | 'correlationId' | 'expiration'>, body: any): Promise<AsyncMessage> {
     const maxAttempts = this._props.maxAttempts || 1
     let attempts = 0
     while (true) try {


### PR DESCRIPTION
Hello! Thank you for this library!
I found an issue where it's not possible to provide a custom correlationId in RPCClient mode.
In this setup we won't get a response because the correlation Id is being overwritten during parameter merging.

For example this client won't get a response 
```
  const envelope: Envelope = {
    correlationId: randomUUID(),
    routingKey: 'example-queue',
  };
  const response = await rpcClient.send(envelope, request);
```